### PR TITLE
Feat: Add comprehensive widget examples playground

### DIFF
--- a/flutter_next/example/lib/main.dart
+++ b/flutter_next/example/lib/main.dart
@@ -1,6 +1,14 @@
+import 'package:example/pages/accordion_example.dart';
+import 'package:example/pages/alerts_example.dart';
 import 'package:example/pages/avatar_example.dart';
-import 'package:example/pages/grid_layout_example.dart'; // Import the new page
+import 'package:example/pages/breadcrumb_example.dart';
+import 'package:example/pages/button_example.dart';
+import 'package:example/pages/grid_layout_example.dart';
+import 'package:example/pages/gridview_example.dart';
+// import 'package:example/pages/avatar_showcase_legacy.dart'; // Renamed old avatar example
+
 import 'package:flutter/material.dart';
+
 // Import other example pages if you have them, e.g.:
 // import 'package:example/animations/all_animations_example.dart';
 
@@ -18,11 +26,21 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
         useMaterial3: true, // Optional: enable Material 3 for modern look
+        // Example of setting a default text theme for explanations if needed globally
+        // textTheme: Theme.of(context).textTheme.copyWith(
+        //       bodySmall: TextStyle(fontStyle: FontStyle.italic, color: Colors.grey.shade700),
+        //     ),
       ),
       home: const ExampleHomePage(), // Set new home page
       routes: {
-        '/avatar': (context) => NextAvatarShowcasePage(),
+        '/alerts': (context) => const AlertsExamplePage(),
+        '/accordion': (context) => const AccordionExamplePage(),
+        '/avatar': (context) => const AvatarExamplePage(), // New avatar examples
+        // '/avatar_legacy': (context) => const NextAvatarShowcasePage(), // Old one, if needed
+        '/breadcrumb': (context) => const BreadcrumbExamplePage(),
+        '/button': (context) => const ButtonExamplePage(),
         '/grid_layout': (context) => const GridLayoutExamplePage(),
+        '/gridview': (context) => const GridViewExamplePage(),
         // Add routes for other examples if needed
         // '/animations': (context) => const AllAnimationsExamplePage(),
       },
@@ -33,6 +51,29 @@ class MyApp extends StatelessWidget {
 class ExampleHomePage extends StatelessWidget {
   const ExampleHomePage({super.key});
 
+  Widget _buildNavigationItem(
+    BuildContext context, {
+    required String title,
+    required String subtitle,
+    required IconData icon,
+    required String routeName,
+  }) {
+    return Column(
+      children: [
+        ListTile(
+          title: Text(title),
+          subtitle: Text(subtitle),
+          leading: Icon(icon, color: Theme.of(context).primaryColor),
+          trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+          onTap: () {
+            Navigator.pushNamed(context, routeName);
+          },
+        ),
+        const Divider(height: 1),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -41,35 +82,63 @@ class ExampleHomePage extends StatelessWidget {
       ),
       body: ListView(
         children: <Widget>[
-          ListTile(
-            title: const Text('Avatar Examples'),
-            subtitle: const Text('Showcases NextAvatar and NextAvatarGroup.'),
-            leading: const Icon(Icons.person_outline),
-            trailing: const Icon(Icons.arrow_forward_ios),
-            onTap: () {
-              Navigator.pushNamed(context, '/avatar');
-            },
+          _buildNavigationItem(
+            context,
+            title: 'Grid & Layout',
+            subtitle: 'NextContainer, NextRow, NextCol, NextResponsiveVisibility.',
+            icon: Icons.grid_on_outlined,
+            routeName: '/grid_layout',
           ),
-          const Divider(),
-          ListTile(
-            title: const Text('Grid Layout Examples'),
-            subtitle: const Text('Demonstrates NextContainer, NextRow, NextCol, and NextResponsiveVisibility.'),
-            leading: const Icon(Icons.grid_on_outlined),
-            trailing: const Icon(Icons.arrow_forward_ios),
-            onTap: () {
-              Navigator.pushNamed(context, '/grid_layout');
-            },
+          _buildNavigationItem(
+            context,
+            title: 'Alerts',
+            subtitle: 'Examples for NextAlerts widget.',
+            icon: Icons.warning_amber_rounded,
+            routeName: '/alerts',
           ),
-          const Divider(),
+          _buildNavigationItem(
+            context,
+            title: 'Accordion',
+            subtitle: 'Examples for NextAccordion widget.',
+            icon: Icons.menu_open_outlined,
+            routeName: '/accordion',
+          ),
+          _buildNavigationItem(
+            context,
+            title: 'Avatars',
+            subtitle: 'Showcases NextAvatar and NextAvatarGroup.',
+            icon: Icons.person_outline,
+            routeName: '/avatar',
+          ),
+           _buildNavigationItem(
+            context,
+            title: 'Breadcrumbs',
+            subtitle: 'Examples for NextBreadCrumb widget.',
+            icon: Icons.arrow_forward_ios_sharp, // Placeholder, find better
+            routeName: '/breadcrumb',
+          ),
+          _buildNavigationItem(
+            context,
+            title: 'Buttons',
+            subtitle: 'Examples for NextButton widget.',
+            icon: Icons.smart_button_outlined,
+            routeName: '/button',
+          ),
+          _buildNavigationItem(
+            context,
+            title: 'GridView',
+            subtitle: 'Examples for NextGridView widget.',
+            icon: Icons.view_module_outlined,
+            routeName: '/gridview',
+          ),
+
           // Add ListTile for other examples here
-          // ListTile(
-          //   title: const Text('Animation Examples'),
-          //   subtitle: const Text('Various animation widgets.'),
-          //   leading: const Icon(Icons.animation),
-          //   trailing: const Icon(Icons.arrow_forward_ios),
-          //   onTap: () {
-          //     Navigator.pushNamed(context, '/animations');
-          //   },
+          // _buildNavigationItem(
+          //   context,
+          //   title: 'Animation Examples',
+          //   subtitle: 'Various animation widgets.',
+          //   icon: Icons.animation,
+          //   routeName: '/animations',
           // ),
         ],
       ),
@@ -83,32 +152,28 @@ class ExampleHomePage extends StatelessWidget {
 // and then navigate to it from the ExampleHomePage.
 
 /*
-class AllWidgetsExamplePage extends StatelessWidget {
-  const AllWidgetsExamplePage({super.key});
+// This was the original content of main.dart's body, could be a separate page
+import 'package:flutter_next/flutter_next.dart'; // For context.titleLarge etc.
+// import 'package:example/animations/zoom_animation_example.dart'; // and other animation examples
+
+class AllWidgetsLegacyExamplePage extends StatelessWidget {
+  const AllWidgetsLegacyExamplePage({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('All Widgets Showcase')),
+      appBar: AppBar(title: const Text('All Widgets Showcase (Legacy)')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // ... (paste the original commented out Column content here) ...
-            // Make sure to import NextGridView, NextRow, NextCol,
-            // various animation examples, NextAvatarGroup, etc.
-            // and also flutter_next.dart for context.titleLarge etc.
-            // For example:
-            // import 'package:flutter_next/flutter_next.dart';
-            // import 'package:example/animations/zoom_animation_example.dart'; // and others
-
             Text(
               "Next Grid View",
               style: Theme.of(context).textTheme.titleLarge,
             ),
-            // NextGridView(...),
-            // ... and so on for all other examples
+            // NextGridView(...), // Needs GridPrefix, NextCol etc. to be defined or imported
+            // ... and so on for all other original examples
           ],
         ),
       ),

--- a/flutter_next/example/lib/pages/accordion_example.dart
+++ b/flutter_next/example/lib/pages/accordion_example.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_next/flutter_next.dart';
+
+class AccordionExamplePage extends StatefulWidget {
+  const AccordionExamplePage({super.key});
+
+  @override
+  State<AccordionExamplePage> createState() => _AccordionExamplePageState();
+}
+
+class _AccordionExamplePageState extends State<AccordionExamplePage> {
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12.0),
+      child: Text(title, style: Theme.of(context).textTheme.titleLarge),
+    );
+  }
+
+  Widget _buildExplanation(BuildContext context, String explanation) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+      child: Text(
+        explanation,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic, color: Colors.grey.shade700),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('NextAccordion Examples'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _buildSectionTitle(context, 'Basic Accordion'),
+            _buildExplanation(context,
+              'Demonstrates a single NextAccordionItem that can be expanded and collapsed. Click the header to toggle visibility of the content.'),
+            NextAccordion(
+              items: [
+                NextAccordionItem(
+                  title: const Text('Basic Accordion Item 1'),
+                  content: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text('This is the content for the first basic accordion item. It can be any widget you like. ' * 3),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Multiple Accordion Items'),
+            _buildExplanation(context,
+              'Shows multiple accordion items within a single NextAccordion widget. '
+              'By default, multiple items can be expanded simultaneously. Set `allowMultipleExpansion: false` to only allow one item to be open at a time (not shown here).'),
+            NextAccordion(
+              items: [
+                NextAccordionItem(
+                  title: const Text('Item A - Click Me'),
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text('Content for Item A. Lorem ipsum dolor sit amet, consectetur adipiscing elit.'),
+                  ),
+                ),
+                NextAccordionItem(
+                  title: const Text('Item B - Also Clickable'),
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('Content for Item B can be more complex:'),
+                        SizedBox(height: 8),
+                        FlutterLogo(size: 40),
+                        SizedBox(height: 8),
+                        Text('End of Item B content.'),
+                      ],
+                    ),
+                  ),
+                ),
+                NextAccordionItem(
+                  title: const Text('Item C - Expand to see more'),
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text('Final item\'s content. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Accordion with Custom Styling & Icons'),
+            _buildExplanation(context,
+              'Illustrates customizing the appearance of accordion items. You can change header background color, icon colors, and even provide completely custom expand/collapse icons.'),
+            NextAccordion(
+              items: [
+                NextAccordionItem(
+                  title: const Text('Custom Header Background', style: TextStyle(color: Colors.white)),
+                  headerBackgroundColor: Colors.deepPurple,
+                  iconColor: Colors.white,
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text('This item has a deep purple header background and white text/icon.'),
+                  ),
+                ),
+                NextAccordionItem(
+                  title: const Text('Custom Icons (Rotated Arrow)'),
+                  customIconOpen: const Icon(Icons.keyboard_arrow_down, color: Colors.teal),
+                  customIconClose: const Icon(Icons.keyboard_arrow_right, color: Colors.teal),
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text('This item uses custom arrow icons for open and close states, colored teal.'),
+                  ),
+                ),
+                 NextAccordionItem(
+                  title: const Text('Custom Icons (Plus/Minus)'),
+                  customIconOpen: const Icon(Icons.remove_circle_outline, color: Colors.redAccent),
+                  customIconClose: const Icon(Icons.add_circle_outline, color: Colors.green),
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text('This item uses plus/minus icons with different colors for open (minus) and close (plus) states.'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Initially Expanded Item'),
+            _buildExplanation(context,
+              'Shows how to make an accordion item initially expanded when the widget is first built using the `isInitiallyExpanded: true` property on a NextAccordionItem.'),
+            NextAccordion(
+              items: [
+                NextAccordionItem(
+                  title: const Text('Item 1 - Starts Collapsed'),
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text('This item is collapsed by default.'),
+                  ),
+                ),
+                NextAccordionItem(
+                  title: const Text('Item 2 - Starts Expanded!'),
+                  isInitiallyExpanded: true,
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text('This item was set to be initially expanded. You can still collapse and expand it normally.'),
+                  ),
+                ),
+                NextAccordionItem(
+                  title: const Text('Item 3 - Also Collapsed'),
+                  content: const Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: Text('This item is also collapsed by default.'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_next/example/lib/pages/alerts_example.dart
+++ b/flutter_next/example/lib/pages/alerts_example.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_next/flutter_next.dart';
+
+class AlertsExamplePage extends StatefulWidget {
+  const AlertsExamplePage({super.key});
+
+  @override
+  State<AlertsExamplePage> createState() => _AlertsExamplePageState();
+}
+
+class _AlertsExamplePageState extends State<AlertsExamplePage> {
+  bool _dismissibleAlertVisible = true;
+  bool _dismissibleIconAlertVisible = true;
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12.0),
+      child: Text(title, style: Theme.of(context).textTheme.titleLarge),
+    );
+  }
+
+  Widget _buildExplanation(BuildContext context, String explanation) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+      child: Text(
+        explanation,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic, color: Colors.grey.shade700),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('NextAlerts Examples'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _buildSectionTitle(context, 'Basic Alert Variants'),
+            _buildExplanation(context,
+              'Displays different predefined alert variants, each with a distinct color scheme. '
+              'These are controlled by the `variant` property of NextAlert.'),
+            NextAlert(
+              variant: NextAlertVariant.primary,
+              child: const Text('This is a primary alert.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.secondary,
+              child: const Text('This is a secondary alert.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.success,
+              child: const Text('This is a success alert.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.danger,
+              child: const Text('This is a danger alert.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.warning,
+              child: const Text('This is a warning alert.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.info,
+              child: const Text('This is an info alert.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.light,
+              child: const Text('This is a light alert.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.dark,
+              child: const Text('This is a dark alert.'),
+            ),
+
+            _buildSectionTitle(context, 'Alerts with Icons'),
+            _buildExplanation(context,
+              'Shows how to include a leading icon in alerts using the `leadingIcon` property. '
+              'The icon will be automatically colored to match the alert variant.'),
+            NextAlert(
+              variant: NextAlertVariant.success,
+              leadingIcon: const Icon(Icons.check_circle_outline),
+              child: const Text('Success! Your action was completed.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.warning,
+              leadingIcon: const Icon(Icons.warning_amber_outlined),
+              child: const Text('Warning: Please check the input fields.'),
+            ),
+            const SizedBox(height: 8),
+            NextAlert(
+              variant: NextAlertVariant.info,
+              leadingIcon: const Icon(Icons.info_outline),
+              child: const Text('Info: System maintenance scheduled for tonight.'),
+            ),
+
+            _buildSectionTitle(context, 'Dismissible Alerts'),
+            _buildExplanation(context,
+              'Demonstrates dismissible alerts. Click the \'x\' icon to close them. '
+              'This requires setting `showCloseButton: true` and providing an `onDismiss` callback to manage visibility.'),
+            if (_dismissibleAlertVisible)
+              NextAlert(
+                variant: NextAlertVariant.primary,
+                showCloseButton: true,
+                onDismiss: () {
+                  setState(() {
+                    _dismissibleAlertVisible = false;
+                  });
+                },
+                child: const Text('This primary alert is dismissible.'),
+              ),
+            if (!_dismissibleAlertVisible)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8.0),
+                child: ElevatedButton(onPressed: () => setState(() => _dismissibleAlertVisible = true), child: const Text('Reset Dismissible Alert')),
+              ),
+            const SizedBox(height: 8),
+            if (_dismissibleIconAlertVisible)
+              NextAlert(
+                variant: NextAlertVariant.danger,
+                leadingIcon: const Icon(Icons.dangerous_outlined),
+                showCloseButton: true,
+                onDismiss: () {
+                  setState(() {
+                    _dismissibleIconAlertVisible = false;
+                  });
+                },
+                child: const Text('This dismissible danger alert also has an icon.'),
+              ),
+            if (!_dismissibleIconAlertVisible)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8.0),
+                child: ElevatedButton(onPressed: () => setState(() => _dismissibleIconAlertVisible = true), child: const Text('Reset Dismissible Icon Alert')),
+              ),
+
+            _buildSectionTitle(context, 'Alert with Custom Rich Content'),
+            _buildExplanation(context,
+              'Illustrates using custom rich content within an alert. '
+              'You can pass any widget as the child, for example, a Column with a title, paragraph, and buttons.'),
+            NextAlert(
+              variant: NextAlertVariant.info,
+              leadingIcon: const Icon(Icons.campaign_outlined),
+              showCloseButton: true, // Optional for this example
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Important Announcement!',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                      color: NextAlertVariant.info.textColor, // Use variant color for consistency
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'We are excited to announce new features coming soon to our platform. '
+                    'Stay tuned for more updates and prepare for an enhanced user experience.',
+                     style: TextStyle(color: NextAlertVariant.info.textColor),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: () {
+                          // Action for 'Learn More'
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Learn More clicked!')),
+                          );
+                        },
+                        child: Text('Learn More', style: TextStyle(color: NextAlertVariant.info.textColor, fontWeight: FontWeight.bold)),
+                      ),
+                      const SizedBox(width: 8),
+                       TextButton(
+                        onPressed: () {
+                           ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Dismiss clicked from custom button!')),
+                          );
+                        },
+                        child: Text('Dismiss', style: TextStyle(color: NextAlertVariant.info.textColor)),
+                      ),
+                    ],
+                  )
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_next/example/lib/pages/avatar_example.dart
+++ b/flutter_next/example/lib/pages/avatar_example.dart
@@ -1,128 +1,247 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_next/flutter_next.dart';
-import 'package:flutter_next/views/next_avatar.dart';
 
-class NextAvatarShowcasePage extends StatelessWidget {
-  const NextAvatarShowcasePage({super.key});
+class AvatarExamplePage extends StatelessWidget {
+  const AvatarExamplePage({super.key});
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text('NextAvatar Showcase'), centerTitle: true),
-      body: SingleChildScrollView(
-        padding: EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Main Heading
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 20),
-              child: Text(
-                'NextAvatar Component Showcase',
-                style: context.textTheme.labelLarge,
-              ),
-            ),
+  Widget _buildSectionTitle(BuildContext context, String title, {bool main = false}) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: main ? 16.0 : 12.0),
+      child: Text(title, style: main ? Theme.of(context).textTheme.headlineSmall : Theme.of(context).textTheme.titleLarge),
+    );
+  }
 
-            // Avatar Variants List
-            _buildAvatarCard(
-              title: 'Small Avatar with Icon and No Border',
-              description:
-                  'A small avatar displaying an icon with no border and a top-right badge.',
-              avatar: NextAvatar(
-                child: IconAvatar(Icons.person),
-                size: AvatarSize.small,
-                border: AvatarBorder.none,
-                badgeColor: Colors.blue,
-                badgePosition: BadgePosition.topRight,
-              ),
-            ),
-            _buildAvatarCard(
-              title: 'Medium Avatar with Image and Thin Border',
-              description:
-                  'A medium-sized avatar with an image and a thin border, bottom-left badge.',
-              avatar: NextAvatar(
-                child: ImageAvatar('https://picsum.photos/200/300'),
-                size: AvatarSize.medium,
-                border: AvatarBorder.thin,
-                badgeColor: Colors.green,
-                badgePosition: BadgePosition.bottomLeft,
-              ),
-            ),
-            _buildAvatarCard(
-              title: 'Large Avatar with Text and Thick Border',
-              description:
-                  'A large avatar with text initials and a thick border, top-left badge.',
-              avatar: NextAvatar(
-                child: TextAvatar('JD'),
-                size: AvatarSize.large,
-                border: AvatarBorder.thick,
-                badgeColor: Colors.orange,
-                badgePosition: BadgePosition.topLeft,
-              ),
-            ),
-            _buildAvatarCard(
-              title: 'Square Avatar with Custom Badge Color',
-              description:
-                  'A square avatar with a custom badge color at the bottom-right.',
-              avatar: NextAvatar(
-                child: IconAvatar(Icons.star),
-                size: AvatarSize.medium,
-                shape: AvatarShape.square,
-                border: AvatarBorder.thin,
-                badgeColor: Colors.red,
-                badgePosition: BadgePosition.bottomRight,
-              ),
-            ),
-            _buildAvatarCard(
-              title: 'Avatar with No Badge',
-              description: 'A large avatar with an image and no badge.',
-              avatar: NextAvatar(
-                child: ImageAvatar('https://picsum.photos/200/300'),
-                size: AvatarSize.large,
-                border: AvatarBorder.none,
-                badgeColor: Colors.transparent,
-                badgePosition: BadgePosition.bottomRight,
-              ),
-            ),
-          ],
-        ),
+  Widget _buildExplanation(BuildContext context, String explanation) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+      child: Text(
+        explanation,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic, color: Colors.grey.shade700),
       ),
     );
   }
 
-  Widget _buildAvatarCard({
-    required String title,
-    required String description,
-    required Widget avatar,
-  }) {
-    return Padding(
-      padding: EdgeInsets.symmetric(vertical: 15),
-      child: Card(
-        elevation: 5,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Avatar Section Title
-              Text(
-                title,
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-              ),
-              SizedBox(height: 10),
+  @override
+  Widget build(BuildContext context) {
+    const String sampleImageUrl = 'https://images.ctfassets.net/hrltx12pl8hq/qGOnNvgfJIe2MytFdIcTQ/429dd7e2cb176f93bf9b21a8f89edc77/Images.jpg?fit=fill&w=175&h=175&fm=webp';
 
-              // Description
-              Text(
-                description,
-                style: TextStyle(fontSize: 14, color: Colors.grey[700]),
-              ),
-              SizedBox(height: 20),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('NextAvatar & Group Examples'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _buildSectionTitle(context, 'NextAvatar Examples', main: true),
 
-              // Avatar Display
-              Center(child: avatar),
-            ],
-          ),
+            _buildSectionTitle(context, 'Basic Image Avatars'),
+            _buildExplanation(context,
+              'Displays a NextAvatar with a network image. The `radius` property controls the size.'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                NextAvatar(
+                  radius: 25,
+                  backgroundImage: const NetworkImage(sampleImageUrl),
+                ),
+                NextAvatar(
+                  radius: 35,
+                  backgroundImage: const NetworkImage(sampleImageUrl),
+                ),
+                NextAvatar(
+                  radius: 45,
+                  backgroundImage: const NetworkImage(sampleImageUrl),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            _buildExplanation(context, 'The above avatars use radii of 25, 35, and 45 respectively.'),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Avatar with Placeholder/Initials'),
+            _buildExplanation(context,
+              'When `backgroundImage` is not provided or fails to load, the `child` widget is displayed. This is typically used for initials or a placeholder icon.'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                NextAvatar(
+                  radius: 30,
+                  backgroundColor: Colors.blueGrey,
+                  child: const Text('JD', style: TextStyle(color: Colors.white, fontSize: 20)),
+                ),
+                NextAvatar(
+                  radius: 30,
+                  backgroundColor: Colors.teal,
+                  child: const Icon(Icons.person, color: Colors.white, size: 30),
+                ),
+                 NextAvatar( // Example of image failing (using a bad URL)
+                  radius: 30,
+                  backgroundImage: const NetworkImage('https://invalid-url-for-testing.com/image.png'),
+                  backgroundColor: Colors.red.shade100,
+                  child: const Icon(Icons.error_outline, color: Colors.red, size: 30),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Avatar with Border & Custom Styling'),
+            _buildExplanation(context,
+              'Avatars can have borders and custom background colors (especially visible when no image is used).'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                NextAvatar(
+                  radius: 30,
+                  backgroundImage: const NetworkImage(sampleImageUrl),
+                  borderColor: Colors.green,
+                  borderWidth: 3.0,
+                ),
+                NextAvatar(
+                  radius: 30,
+                  backgroundColor: Colors.purple.shade100,
+                  borderColor: Colors.purple,
+                  borderWidth: 2.0,
+                  child: const Text('S', style: TextStyle(color: Colors.purple, fontSize: 24, fontWeight: FontWeight.bold)),
+                ),
+                NextAvatar(
+                  radius: 30,
+                  backgroundImage: const NetworkImage(sampleImageUrl),
+                  shape: NextAvatarShape.square, // Different shape
+                  borderColor: Colors.orange,
+                  borderWidth: 2.5,
+                ),
+              ],
+            ),
+            const SizedBox(height: 30),
+
+            _buildSectionTitle(context, 'NextAvatarGroup Examples', main: true),
+
+            _buildSectionTitle(context, 'Basic Avatar Group'),
+            _buildExplanation(context,
+              'Shows a basic group of overlapping avatars. Avatars are provided via the `avatarImages` list (ImageProviders) or `children` (List<NextAvatar>).'),
+            NextAvatarGroup(
+              avatarImages: List.generate(4, (index) => const NetworkImage(sampleImageUrl)),
+              radius: 25,
+            ),
+            const SizedBox(height: 20),
+             _buildExplanation(context, 'Using `children` property with `NextAvatar` widgets directly:'),
+             NextAvatarGroup(
+              radius: 25,
+              children: [
+                NextAvatar(radius: 25, backgroundImage: const NetworkImage(sampleImageUrl)),
+                NextAvatar(radius: 25, backgroundColor: Colors.blue, child: const Text('A', style: TextStyle(color: Colors.white))),
+                NextAvatar(radius: 25, backgroundImage: const NetworkImage(sampleImageUrl)),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+
+            _buildSectionTitle(context, 'Group with Display Limit & Excess Count'),
+            _buildExplanation(context,
+              'Limits the number of displayed avatars using `displayLimit` and shows an excess count for the hidden ones. `maxAvatarsToDisplay` is an alias for `displayLimit`.'),
+            NextAvatarGroup(
+              avatarImages: List.generate(8, (index) => NetworkImage('$sampleImageUrl?v=$index')), // Unique URLs
+              radius: 25,
+              displayLimit: 4, // or maxAvatarsToDisplay
+              avatarBackgroundColor: Colors.grey.shade300, // For the excess count
+              excessCountTextStyle: const TextStyle(color: Colors.black, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Custom Excess Count Builder'),
+            _buildExplanation(context,
+              'Allows complete customization of the excess count indicator using the `excessCountBuilder` function.'),
+            NextAvatarGroup(
+              avatarImages: List.generate(7, (index) => NetworkImage('$sampleImageUrl?id=$index')),
+              radius: 28,
+              displayLimit: 3,
+              excessCountBuilder: (context, excessCount) {
+                return Container(
+                  width: 2 * 28.0, // Match avatar diameter
+                  height: 2 * 28.0,
+                  decoration: BoxDecoration(
+                    color: Colors.redAccent,
+                    shape: BoxShape.circle,
+                    border: Border.all(color: Colors.white, width: 2),
+                  ),
+                  child: Center(
+                    child: Text(
+                      '+$excessCount',
+                      style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Custom Avatar Builder within Group'),
+            _buildExplanation(context,
+              'The `avatarBuilder` allows customization of each avatar within the group, e.g., to add status indicators or different shapes. This takes precedence over `avatarImages`.'),
+            NextAvatarGroup(
+              // avatarImages list is still needed to determine the count if using avatarBuilder for N items
+              avatarImages: List.generate(5, (index) => const NetworkImage(sampleImageUrl)), // Length determines items
+              radius: 30,
+              displayLimit: 5, // Show all for this example
+              avatarBuilder: (context, index) {
+                // Example: Add a green dot for online status on some avatars
+                bool isOnline = index % 2 == 0;
+                return Stack(
+                  children: [
+                    NextAvatar(
+                      radius: 30,
+                      backgroundImage: NetworkImage('$sampleImageUrl?item=$index'),
+                      borderColor: Colors.white, // Border for stacking effect
+                      borderWidth: 1.5,
+                    ),
+                    if (isOnline)
+                      Positioned(
+                        bottom: 2,
+                        right: 2,
+                        child: Container(
+                          width: 12,
+                          height: 12,
+                          decoration: BoxDecoration(
+                            color: Colors.greenAccent,
+                            shape: BoxShape.circle,
+                            border: Border.all(color: Colors.white, width: 1.5),
+                          ),
+                        ),
+                      ),
+                  ],
+                );
+              },
+            ),
+            const SizedBox(height: 20),
+             _buildSectionTitle(context, 'Adjusting Overlap with `widthReductionFactor`'),
+            _buildExplanation(context,
+              '`widthReductionFactor` controls how much each subsequent avatar overlaps the previous one. Default is 0.4 (40% of radius). Smaller value = more overlap.'),
+            Row(
+              children: [
+                Expanded(child: Column(children: [
+                  const Text('Factor: 0.2 (More overlap)'),
+                  const SizedBox(height: 4),
+                  NextAvatarGroup(
+                    avatarImages: List.generate(4, (index) => NetworkImage('$sampleImageUrl?r=0.2&i=$index')),
+                    radius: 20,
+                    widthReductionFactor: 0.2,
+                  )
+                ])),
+                const SizedBox(width: 10),
+                Expanded(child: Column(children: [
+                  const Text('Factor: 0.6 (Less overlap)'),
+                  const SizedBox(height: 4),
+                  NextAvatarGroup(
+                    avatarImages: List.generate(4, (index) => NetworkImage('$sampleImageUrl?r=0.6&i=$index')),
+                    radius: 20,
+                    widthReductionFactor: 0.6,
+                  )
+                ])),
+              ],
+            )
+          ],
         ),
       ),
     );

--- a/flutter_next/example/lib/pages/avatar_showcase_legacy.dart
+++ b/flutter_next/example/lib/pages/avatar_showcase_legacy.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_next/flutter_next.dart';
+import 'package:flutter_next/views/next_avatar.dart';
+
+class NextAvatarShowcasePage extends StatelessWidget {
+  const NextAvatarShowcasePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('NextAvatar Showcase'), centerTitle: true),
+      body: SingleChildScrollView(
+        padding: EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Main Heading
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 20),
+              child: Text(
+                'NextAvatar Component Showcase',
+                style: context.textTheme.labelLarge,
+              ),
+            ),
+
+            // Avatar Variants List
+            _buildAvatarCard(
+              title: 'Small Avatar with Icon and No Border',
+              description:
+                  'A small avatar displaying an icon with no border and a top-right badge.',
+              avatar: NextAvatar(
+                child: IconAvatar(Icons.person),
+                size: AvatarSize.small,
+                border: AvatarBorder.none,
+                badgeColor: Colors.blue,
+                badgePosition: BadgePosition.topRight,
+              ),
+            ),
+            _buildAvatarCard(
+              title: 'Medium Avatar with Image and Thin Border',
+              description:
+                  'A medium-sized avatar with an image and a thin border, bottom-left badge.',
+              avatar: NextAvatar(
+                child: ImageAvatar('https://picsum.photos/200/300'),
+                size: AvatarSize.medium,
+                border: AvatarBorder.thin,
+                badgeColor: Colors.green,
+                badgePosition: BadgePosition.bottomLeft,
+              ),
+            ),
+            _buildAvatarCard(
+              title: 'Large Avatar with Text and Thick Border',
+              description:
+                  'A large avatar with text initials and a thick border, top-left badge.',
+              avatar: NextAvatar(
+                child: TextAvatar('JD'),
+                size: AvatarSize.large,
+                border: AvatarBorder.thick,
+                badgeColor: Colors.orange,
+                badgePosition: BadgePosition.topLeft,
+              ),
+            ),
+            _buildAvatarCard(
+              title: 'Square Avatar with Custom Badge Color',
+              description:
+                  'A square avatar with a custom badge color at the bottom-right.',
+              avatar: NextAvatar(
+                child: IconAvatar(Icons.star),
+                size: AvatarSize.medium,
+                shape: AvatarShape.square,
+                border: AvatarBorder.thin,
+                badgeColor: Colors.red,
+                badgePosition: BadgePosition.bottomRight,
+              ),
+            ),
+            _buildAvatarCard(
+              title: 'Avatar with No Badge',
+              description: 'A large avatar with an image and no badge.',
+              avatar: NextAvatar(
+                child: ImageAvatar('https://picsum.photos/200/300'),
+                size: AvatarSize.large,
+                border: AvatarBorder.none,
+                badgeColor: Colors.transparent,
+                badgePosition: BadgePosition.bottomRight,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAvatarCard({
+    required String title,
+    required String description,
+    required Widget avatar,
+  }) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: 15),
+      child: Card(
+        elevation: 5,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Avatar Section Title
+              Text(
+                title,
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              SizedBox(height: 10),
+
+              // Description
+              Text(
+                description,
+                style: TextStyle(fontSize: 14, color: Colors.grey[700]),
+              ),
+              SizedBox(height: 20),
+
+              // Avatar Display
+              Center(child: avatar),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_next/example/lib/pages/breadcrumb_example.dart
+++ b/flutter_next/example/lib/pages/breadcrumb_example.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_next/flutter_next.dart';
+
+class BreadcrumbExamplePage extends StatelessWidget {
+  const BreadcrumbExamplePage({super.key});
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12.0),
+      child: Text(title, style: Theme.of(context).textTheme.titleLarge),
+    );
+  }
+
+  Widget _buildExplanation(BuildContext context, String explanation) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+      child: Text(
+        explanation,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic, color: Colors.grey.shade700),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('NextBreadCrumb Examples'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _buildSectionTitle(context, 'Basic Breadcrumb'),
+            _buildExplanation(context,
+              'A simple breadcrumb trail for navigation hierarchy. Each `NextBreadCrumbItem` represents a level.'),
+            NextBreadCrumb(
+              items: [
+                NextBreadCrumbItem(text: 'Home'),
+                NextBreadCrumbItem(text: 'Products'),
+                NextBreadCrumbItem(text: 'Electronics'),
+                NextBreadCrumbItem(text: 'Laptops', isLast: true), // isLast typically styles it as non-interactive
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Breadcrumb with Custom Separator'),
+            _buildExplanation(context,
+              'Demonstrates customizing the separator between breadcrumb items using the `separator` property. You can use any widget as a separator.'),
+            _buildExplanation(context, 'Using Text(">>") as separator:'),
+            NextBreadCrumb(
+              separator: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 6.0),
+                child: Text('>>', style: TextStyle(color: Colors.grey)),
+              ),
+              items: [
+                NextBreadCrumbItem(text: 'Dashboard'),
+                NextBreadCrumbItem(text: 'Settings'),
+                NextBreadCrumbItem(text: 'Profile', isLast: true),
+              ],
+            ),
+            const SizedBox(height: 10),
+            _buildExplanation(context, 'Using an Icon as separator:'),
+            NextBreadCrumb(
+              separator: const Icon(Icons.arrow_forward_ios, size: 12.0, color: Colors.blueAccent),
+              items: [
+                NextBreadCrumbItem(text: 'Categories'),
+                NextBreadCrumbItem(text: 'Books'),
+                NextBreadCrumbItem(text: 'Fiction', isLast: true),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Breadcrumb with Clickable Items (Actions)'),
+            _buildExplanation(context,
+              'Shows breadcrumb items that are interactive. Tapping an item can trigger an `onTap` action. The last item is usually not clickable.'),
+            NextBreadCrumb(
+              items: [
+                NextBreadCrumbItem(
+                  text: 'Home Page',
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Home Page tapped!'), duration: Duration(seconds: 1)),
+                    );
+                  },
+                ),
+                NextBreadCrumbItem(
+                  text: 'User Area',
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('User Area tapped!'), duration: Duration(seconds: 1)),
+                    );
+                  },
+                ),
+                NextBreadCrumbItem(text: 'Edit Details', isLast: true),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Breadcrumb with Icons & Custom Styling'),
+            _buildExplanation(context,
+              'Illustrates adding leading icons to breadcrumb items for better visual guidance and custom text styling.'),
+            NextBreadCrumb(
+              activeItemColor: Colors.deepPurple, // Color for non-last items
+              lastItemColor: Colors.black54,    // Color for the last item
+              separator: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 4.0),
+                child: Text('/', style: TextStyle(color: Colors.orange)),
+              ),
+              items: [
+                NextBreadCrumbItem(
+                  leading: const Icon(Icons.home_filled, size: 18, color: Colors.deepPurple),
+                  text: 'Main',
+                  onTap: () {}, // Make it appear clickable
+                ),
+                NextBreadCrumbItem(
+                  leading: const Icon(Icons.folder, size: 18, color: Colors.deepPurple),
+                  text: 'Documents',
+                   onTap: () {},
+                ),
+                NextBreadCrumbItem(
+                  leading: const Icon(Icons.description, size: 18, color: Colors.black54),
+                  text: 'Report.docx',
+                  isLast: true,
+                ),
+              ],
+            ),
+             const SizedBox(height: 10),
+             _buildExplanation(context, 'Another example with different styling:'),
+             NextBreadCrumb(
+              activeItemColor: Colors.blue.shade700,
+              lastItemColor: Colors.grey.shade700,
+              itemTextStyle: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+              lastItemTextStyle: const TextStyle(fontSize: 14, fontWeight: FontWeight.normal),
+              items: [
+                NextBreadCrumbItem(text: 'Store', onTap: () {}),
+                NextBreadCrumbItem(text: 'Apparel', onTap: () {}),
+                NextBreadCrumbItem(text: 'Shirts', onTap: () {}),
+                NextBreadCrumbItem(text: 'Summer Collection', isLast: true),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_next/example/lib/pages/button_example.dart
+++ b/flutter_next/example/lib/pages/button_example.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_next/flutter_next.dart';
+
+class ButtonExamplePage extends StatelessWidget {
+  const ButtonExamplePage({super.key});
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12.0),
+      child: Text(title, style: Theme.of(context).textTheme.titleLarge),
+    );
+  }
+
+  Widget _buildExplanation(BuildContext context, String explanation) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+      child: Text(
+        explanation,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic, color: Colors.grey.shade700),
+      ),
+    );
+  }
+
+  void _showSnackbar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), duration: const Duration(seconds: 1)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('NextButton Examples'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _buildSectionTitle(context, 'Button Variants (Solid)'),
+            _buildExplanation(context,
+              'Showcases various button styles based on predefined variants (primary, secondary, success, etc.) using the `variant` property.'),
+            Wrap(
+              spacing: 8.0,
+              runSpacing: 8.0,
+              children: NextButtonVariant.values.map((variant) {
+                return NextButton(
+                  variant: variant,
+                  onPressed: () => _showSnackbar(context, '${variant.name.capitalize()} Button Clicked'),
+                  child: Text(variant.name.capitalize()),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Outline Buttons'),
+            _buildExplanation(context,
+              'Demonstrates outline button styles using `isOutlined: true` combined with different variants.'),
+            Wrap(
+              spacing: 8.0,
+              runSpacing: 8.0,
+              children: NextButtonVariant.values.map((variant) {
+                return NextButton(
+                  variant: variant,
+                  isOutlined: true,
+                  onPressed: () => _showSnackbar(context, 'Outline ${variant.name.capitalize()} Clicked'),
+                  child: Text('Outline ${variant.name.capitalize()}'),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Buttons with Icons'),
+            _buildExplanation(context,
+              'Illustrates adding icons to buttons, either before (leading) or after (trailing) the text, or icon-only buttons.'),
+            Wrap(
+              spacing: 8.0,
+              runSpacing: 8.0,
+              alignment: WrapAlignment.start,
+              children: [
+                NextButton(
+                  variant: NextButtonVariant.primary,
+                  leadingIcon: const Icon(Icons.send),
+                  onPressed: () => _showSnackbar(context, 'Send Button Clicked'),
+                  child: const Text('Send'),
+                ),
+                NextButton(
+                  variant: NextButtonVariant.success,
+                  trailingIcon: const Icon(Icons.check_circle_outline),
+                   onPressed: () => _showSnackbar(context, 'Confirm Button Clicked'),
+                  child: const Text('Confirm'),
+                ),
+                NextButton(
+                  variant: NextButtonVariant.info,
+                  isOutlined: true,
+                  leadingIcon: const Icon(Icons.info_outline),
+                  onPressed: () => _showSnackbar(context, 'Info Button Clicked'),
+                  child: const Text('More Info'),
+                ),
+                 NextButton.icon(
+                  variant: NextButtonVariant.danger,
+                  icon: const Icon(Icons.delete_forever),
+                  onPressed: () => _showSnackbar(context, 'Delete Icon Button Clicked'),
+                ),
+                NextButton.icon(
+                  variant: NextButtonVariant.secondary,
+                  isOutlined: true,
+                  icon: const Icon(Icons.settings),
+                  onPressed: () => _showSnackbar(context, 'Settings Icon Button Clicked'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Button Sizes'),
+            _buildExplanation(context,
+              'Shows buttons of different sizes (small, medium (default), large) using the `buttonSize` property.'),
+            Wrap(
+              spacing: 8.0,
+              runSpacing: 8.0,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                NextButton(
+                  variant: NextButtonVariant.primary,
+                  buttonSize: NextButtonSize.small,
+                  onPressed: () => _showSnackbar(context, 'Small Button Clicked'),
+                  child: const Text('Small Button'),
+                ),
+                NextButton(
+                  variant: NextButtonVariant.secondary,
+                  // buttonSize: NextButtonSize.medium, (default)
+                  onPressed: () => _showSnackbar(context, 'Medium Button Clicked'),
+                  child: const Text('Medium (Default)'),
+                ),
+                NextButton(
+                  variant: NextButtonVariant.success,
+                  buttonSize: NextButtonSize.large,
+                  onPressed: () => _showSnackbar(context, 'Large Button Clicked'),
+                  child: const Text('Large Button'),
+                ),
+                 NextButton.icon(
+                  variant: NextButtonVariant.warning,
+                  buttonSize: NextButtonSize.small,
+                  icon: const Icon(Icons.warning_amber),
+                  onPressed: () => _showSnackbar(context, 'Small Icon Button Clicked'),
+                ),
+                NextButton.icon(
+                  variant: NextButtonVariant.info,
+                  buttonSize: NextButtonSize.large,
+                  icon: const Icon(Icons.info),
+                  onPressed: () => _showSnackbar(context, 'Large Icon Button Clicked'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Full Width Button (Expanded)'),
+            _buildExplanation(context,
+              'A button can take the full available width by setting `expanded: true`. This is useful for forms or call-to-action buttons at the bottom of a section.'),
+            NextButton(
+              variant: NextButtonVariant.primary,
+              expanded: true,
+              onPressed: () => _showSnackbar(context, 'Full Width Button Clicked'),
+              child: const Text('Submit Form (Full Width)'),
+            ),
+            const SizedBox(height: 8),
+             NextButton(
+              variant: NextButtonVariant.dark,
+              isOutlined: true,
+              expanded: true,
+              leadingIcon: const Icon(Icons.add_shopping_cart),
+              onPressed: () => _showSnackbar(context, 'Add to Cart Full Width Clicked'),
+              child: const Text('Add to Cart (Full Width Outline)'),
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'Disabled Buttons'),
+            _buildExplanation(context,
+              'Demonstrates disabled buttons that are not interactive. This is achieved by setting `onPressed: null`.'),
+            Wrap(
+              spacing: 8.0,
+              runSpacing: 8.0,
+              children: [
+                const NextButton(
+                  variant: NextButtonVariant.primary,
+                  onPressed: null, // Disabled
+                  child: Text('Disabled Primary'),
+                ),
+                const NextButton(
+                  variant: NextButtonVariant.secondary,
+                  isOutlined: true,
+                  onPressed: null, // Disabled
+                  child: Text('Disabled Outline'),
+                ),
+                NextButton.icon(
+                  variant: NextButtonVariant.success,
+                  icon: const Icon(Icons.check),
+                  onPressed: null, // Disabled
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+extension StringExtension on String {
+    String capitalize() {
+      return "${this[0].toUpperCase()}${substring(1).toLowerCase()}";
+    }
+}

--- a/flutter_next/example/lib/pages/grid_layout_example.dart
+++ b/flutter_next/example/lib/pages/grid_layout_example.dart
@@ -4,212 +4,306 @@ import 'package:flutter_next/flutter_next.dart';
 class GridLayoutExamplePage extends StatelessWidget {
   const GridLayoutExamplePage({super.key});
 
+  Widget _buildSectionTitle(BuildContext context, String title, {bool sub = false}) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: sub ? 8.0 : 12.0, horizontal: sub ? 16.0 : 0.0),
+      child: Text(title, style: sub ? Theme.of(context).textTheme.titleLarge : Theme.of(context).textTheme.headlineSmall),
+    );
+  }
+
+  Widget _buildExplanation(BuildContext context, String explanation) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0, bottom: 8.0, left: 8.0, right: 8.0),
+      child: Text(
+        explanation,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic, color: Colors.grey.shade700),
+      ),
+    );
+  }
+
+  Widget _exampleBox(String text, Color color, {double height = 100}) {
+    return Container(
+      padding: const EdgeInsets.all(8),
+      color: color,
+      height: height,
+      child: Center(child: Text(text, textAlign: TextAlign.center, style: const TextStyle(fontSize: 12, color: Colors.black87))),
+    );
+  }
+
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Grid Layout Examples'),
+        title: const Text('Grid & Layout Examples'),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Text(
-              'NextContainer Examples',
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-            const SizedBox(height: 10),
-            Text('Fluid Container (takes full width):', style: Theme.of(context).textTheme.titleMedium),
+            _buildSectionTitle(context, 'NextContainer Examples'),
+
+            _buildSectionTitle(context, 'Fluid Container', sub: true),
+            _buildExplanation(context,
+              'A fluid container (`fluid: true`) takes up the entire available width of its parent. '
+              'It is useful for full-width sections or banners.'),
             NextContainer(
               fluid: true,
               decoration: BoxDecoration(
-                color: Colors.blue.shade100,
-                border: Border.all(color: Colors.blue.shade300),
+                color: Colors.blue.shade50,
+                border: Border.all(color: Colors.blue.shade200),
               ),
               padding: const EdgeInsets.all(8.0),
               children: [
-                Container(
-                  color: Colors.blue.shade200,
-                  padding: const EdgeInsets.all(8.0),
-                  child: const Text('This container is fluid.'),
-                ),
+                _exampleBox('This container is fluid. Resize your window to see it adapt.', Colors.blue.shade100, height: 60),
               ],
             ),
-            const SizedBox(height: 10),
-            Text('Fixed-width Container (centered with max width based on breakpoint):', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 15),
+
+            _buildSectionTitle(context, 'Fixed-Width Container', sub: true),
+            _buildExplanation(context,
+              'A fixed-width container (`fluid: false`, default) centers itself and has a maximum width that changes based on screen breakpoints (e.g., 540px on SM, 720px on MD, etc.). '
+              'This is standard for main content areas.'),
             NextContainer(
-              fluid: false, // Default
+              fluid: false,
               decoration: BoxDecoration(
-                color: Colors.green.shade100,
-                border: Border.all(color: Colors.green.shade300),
+                color: Colors.green.shade50,
+                border: Border.all(color: Colors.green.shade200),
               ),
               padding: const EdgeInsets.all(8.0),
               children: [
-                Container(
-                  color: Colors.green.shade200,
-                  padding: const EdgeInsets.all(8.0),
-                  child: const Text('This container is fixed-width.'),
-                ),
+                 _exampleBox('This container is fixed-width. Its max width changes at breakpoints.', Colors.green.shade100, height: 60),
               ],
             ),
-            const SizedBox(height: 10),
-            Text('Container with custom padding and decoration:', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 15),
+
+            _buildSectionTitle(context, 'Container with Custom Styling & Alignment', sub: true),
+            _buildExplanation(context,
+              'NextContainer supports `padding`, `decoration` (for background colors, borders, shadows), and `alignment` (for its content if the container itself is wider than its content due to fixed-width behavior).'),
             NextContainer(
+              alignment: Alignment.center, // Aligns the Column child if screen is wider than max-width
               decoration: BoxDecoration(
-                color: Colors.purple.shade100,
-                borderRadius: BorderRadius.circular(8.0),
+                color: Colors.purple.shade50,
+                borderRadius: BorderRadius.circular(12.0),
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.grey.withOpacity(0.5),
-                    spreadRadius: 2,
-                    blurRadius: 5,
-                    offset: const Offset(0, 3),
+                    color: Colors.grey.withOpacity(0.4),
+                    spreadRadius: 1,
+                    blurRadius: 6,
+                    offset: const Offset(0, 2),
                   ),
                 ],
               ),
               padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 15),
               children: [
-                Container(
-                  color: Colors.purple.shade200,
-                  padding: const EdgeInsets.all(8.0),
-                  child: const Text('This container has custom styling.'),
-                ),
+                _exampleBox('This container has custom padding, border radius, and a shadow. Content is centered if fixed-width.', Colors.purple.shade100, height: 60),
               ],
             ),
-            const SizedBox(height: 20),
-            Text(
-              'NextRow and NextCol Examples',
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-            const SizedBox(height: 10),
-            Text('Basic Responsive Grid:', style: Theme.of(context).textTheme.titleMedium),
+            const Divider(height: 40, thickness: 1),
+
+            _buildSectionTitle(context, 'NextRow & NextCol: Sizing'),
+            _buildExplanation(context,
+              'Columns (`NextCol`) are placed inside Rows (`NextRow`). The `sizes` property of `NextCol` uses a 12-column grid system. '
+              'You specify column widths for different breakpoints (xs, sm, md, lg, xl, xxl). E.g., `col-xs-12` is full-width on extra-small screens, `col-sm-6` is half-width on small screens.'),
+
+            _buildSectionTitle(context, 'Example 1: Basic Responsive Sizing', sub: true),
             NextRow(
               children: [
                 NextCol(
                   sizes: 'col-xs-12 col-sm-6 col-md-4 col-lg-3',
-                  child: Container(
-                    color: Colors.red.shade200,
-                    height: 100,
-                    child: const Center(child: Text('Col 1\nXS:12, SM:6, MD:4, LG:3')),
-                  ),
+                  child: _exampleBox('Col 1\nXS:12 SM:6 MD:4 LG:3', Colors.red.shade100),
                 ),
                 NextCol(
                   sizes: 'col-xs-12 col-sm-6 col-md-4 col-lg-3',
-                  child: Container(
-                    color: Colors.orange.shade200,
-                    height: 100,
-                    child: const Center(child: Text('Col 2\nXS:12, SM:6, MD:4, LG:3')),
-                  ),
+                  child: _exampleBox('Col 2\nXS:12 SM:6 MD:4 LG:3', Colors.orange.shade100),
                 ),
                 NextCol(
                   sizes: 'col-xs-12 col-sm-6 col-md-4 col-lg-3',
-                  child: Container(
-                    color: Colors.yellow.shade200,
-                    height: 100,
-                    child: const Center(child: Text('Col 3\nXS:12, SM:6, MD:4, LG:3')),
-                  ),
+                  child: _exampleBox('Col 3\nXS:12 SM:6 MD:4 LG:3', Colors.yellow.shade100),
                 ),
                 NextCol(
-                  sizes: 'col-xs-12 col-sm-6 col-md-12 col-lg-3', // Full width on MD
-                  child: Container(
-                    color: Colors.teal.shade200,
-                    height: 100,
-                    child: const Center(child: Text('Col 4\nXS:12, SM:6, MD:12, LG:3')),
-                  ),
+                  sizes: 'col-xs-12 col-sm-6 col-md-12 col-lg-3',
+                  child: _exampleBox('Col 4\nXS:12 SM:6 MD:12 LG:3', Colors.teal.shade100),
                 ),
               ],
             ),
-            const SizedBox(height: 15),
-            Text('Column Offsetting:', style: Theme.of(context).textTheme.titleMedium),
+             const SizedBox(height: 15),
+            _buildSectionTitle(context, 'Example 2: Mixed Sizing', sub: true),
+             NextRow(
+              children: [
+                NextCol(
+                  sizes: 'col-md-8',
+                  child: _exampleBox('Takes 8 of 12 columns on MD and up', Colors.indigo.shade100),
+                ),
+                NextCol(
+                  sizes: 'col-md-4',
+                  child: _exampleBox('Takes 4 of 12 columns on MD and up', Colors.pink.shade100),
+                ),
+              ],
+            ),
+            const Divider(height: 40, thickness: 1),
+
+            _buildSectionTitle(context, 'NextRow & NextCol: Offsetting'),
+             _buildExplanation(context,
+              'The `offsets` property of `NextCol` pushes columns to the right. '
+              'E.g., `offset-md-3` pushes a column by 3 column units on medium screens and larger.'),
+            _buildSectionTitle(context, 'Example 1: Centering a Column', sub: true),
             NextRow(
               children: [
                 NextCol(
                   sizes: 'col-md-6',
-                  offsets: 'offset-md-3', // Centered on MD and up
-                  child: Container(
-                    color: Colors.cyan.shade200,
-                    height: 80,
-                    child: const Center(child: Text('Col MD-6, Offset MD-3')),
-                  ),
+                  offsets: 'offset-md-3',
+                  child: _exampleBox('Col MD-6, Offset MD-3 (Effectively Centered)', Colors.cyan.shade100, height: 80),
                 ),
               ],
             ),
             const SizedBox(height: 15),
-            Text('Column Reordering:', style: Theme.of(context).textTheme.titleMedium),
+            _buildSectionTitle(context, 'Example 2: Responsive Offsetting', sub: true),
+            NextRow(
+              children: [
+                NextCol(
+                  sizes: 'col-sm-5 col-lg-4',
+                  offsets: 'offset-sm-1 offset-lg-2',
+                  child: _exampleBox('Col SM-5 LG-4\nOffset SM-1 LG-2', Colors.lime.shade100, height: 80),
+                ),
+                 NextCol(
+                  sizes: 'col-sm-4 col-lg-3',
+                  offsets: 'offset-sm-1 offset-lg-2',
+                  child: _exampleBox('Col SM-4 LG-3\nOffset SM-1 LG-2', Colors.brown.shade100, height: 80),
+                ),
+              ],
+            ),
+            const Divider(height: 40, thickness: 1),
+
+            _buildSectionTitle(context, 'NextRow & NextCol: Ordering'),
+            _buildExplanation(context,
+              'The `order` property of `NextCol` changes the visual order of columns independently of their source order. '
+              'E.g., `order-sm-2` makes a column appear second on small screens. `order-md-1` makes it first on medium screens.'),
+            _buildSectionTitle(context, 'Example 1: Simple Reordering', sub: true),
             NextRow(
               children: [
                 NextCol(
                   sizes: 'col-sm-8 col-md-6',
-                  order: 'order-sm-2 order-md-1', // Second on SM, First on MD
-                  child: Container(
-                    color: Colors.lightBlue.shade200,
-                    height: 100,
-                    child: const Center(child: Text('Content A\nOrder: SM-2, MD-1')),
-                  ),
+                  order: 'order-sm-2 order-md-1',
+                  child: _exampleBox('Content A\nOrder: SM-2, MD-1', Colors.lightBlue.shade100),
                 ),
                 NextCol(
                   sizes: 'col-sm-4 col-md-6',
-                  order: 'order-sm-1 order-md-2', // First on SM, Second on MD
-                  child: Container(
-                    color: Colors.lightGreen.shade200,
-                    height: 100,
-                    child: const Center(child: Text('Content B\nOrder: SM-1, MD-2')),
-                  ),
+                  order: 'order-sm-1 order-md-2',
+                  child: _exampleBox('Content B\nOrder: SM-1, MD-2', Colors.lightGreen.shade100),
+                ),
+              ],
+            ),
+             const SizedBox(height: 15),
+            _buildSectionTitle(context, 'Example 2: Complex Reordering (3+ items)', sub: true),
+             NextRow(
+              children: [
+                NextCol(
+                  sizes: 'col-xs-12 col-md-4',
+                  order: 'order-xs-3 order-md-1',
+                  child: _exampleBox('Item X (Third on XS, First on MD)', Colors.purple.shade100),
+                ),
+                NextCol(
+                  sizes: 'col-xs-12 col-md-4',
+                  order: 'order-xs-1 order-md-2',
+                  child: _exampleBox('Item Y (First on XS, Second on MD)', Colors.deepOrange.shade100),
+                ),
+                 NextCol(
+                  sizes: 'col-xs-12 col-md-4',
+                  order: 'order-xs-2 order-md-3',
+                  child: _exampleBox('Item Z (Second on XS, Third on MD)', Colors.teal.shade200),
+                ),
+              ],
+            ),
+            const Divider(height: 40, thickness: 1),
+
+            _buildSectionTitle(context, 'NextRow & NextCol: Visibility'),
+            _buildExplanation(context,
+              'The `invisibleForSizes` property of `NextCol` hides the column on specified breakpoints. '
+              'Provide a space-separated string of breakpoint names (e.g., "xs sm" to hide on extra-small and small).'),
+            _buildSectionTitle(context, 'Example 1: Hide on Specific Breakpoints', sub: true),
+            NextRow(
+              children: [
+                NextCol(
+                  sizes: 'col-6 col-md-4',
+                  child: _exampleBox('Always Visible Col', Colors.pink.shade100, height: 80),
+                ),
+                NextCol(
+                  sizes: 'col-6 col-md-4',
+                  invisibleForSizes: 'xs sm',
+                  child: _exampleBox('Hidden on XS & SM', Colors.amber.shade100, height: 80),
+                ),
+                 NextCol(
+                  sizes: 'col-md-4', // Only specify sizes for when it's visible
+                  invisibleForSizes: 'md',
+                  child: _exampleBox('Hidden on MD only', Colors.grey.shade300, height: 80),
                 ),
               ],
             ),
             const SizedBox(height: 15),
-            Text('Hiding Columns:', style: Theme.of(context).textTheme.titleMedium),
+            _buildSectionTitle(context, 'Example 2: Show only on specific breakpoints', sub: true),
+            _buildExplanation(context, 'To show a column *only* on specific breakpoints, you make it invisible on all *other* breakpoints.'),
             NextRow(
               children: [
-                NextCol(
-                  sizes: 'col-6',
-                  child: Container(
-                    color: Colors.pink.shade100,
-                    height: 80,
-                    child: const Center(child: Text('Always Visible Col')),
-                  ),
+                 NextCol(
+                  sizes: 'col-12', // Full width when visible
+                  invisibleForSizes: 'xs sm lg xl xxl', // Hidden on all except MD
+                  child: _exampleBox('VISIBLE ONLY ON MD', Colors.red.shade200, height: 60),
                 ),
                 NextCol(
-                  sizes: 'col-6',
-                  invisibleForSizes: 'xs sm', // Hidden on XS and SM
-                  child: Container(
-                    color: Colors.amber.shade200,
-                    height: 80,
-                    child: const Center(child: Text('Hidden on XS & SM')),
-                  ),
+                  sizes: 'col-12', // Full width when visible
+                  invisibleForSizes: 'md lg xl xxl', // Hidden on all except XS and SM
+                  child: _exampleBox('VISIBLE ONLY ON XS & SM', Colors.blue.shade200, height: 60),
                 ),
               ],
             ),
-            const SizedBox(height: 20),
-            Text(
-              'NextResponsiveVisibility Examples',
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-            const SizedBox(height: 10),
-            Text('Conditionally displaying widgets:', style: Theme.of(context).textTheme.titleMedium),
+            const Divider(height: 40, thickness: 1),
+
+            _buildSectionTitle(context, 'NextResponsiveVisibility Examples'),
+            _buildExplanation(context,
+              '`NextResponsiveVisibility` conditionally renders its child widget based on the active breakpoint. '
+              'The `breakpoints` property takes a space-separated string of breakpoint names (e.g., "lg xl").'),
+
+            _buildSectionTitle(context, 'Example 1: Show on specific breakpoints', sub: true),
             NextResponsiveVisibility(
-              breakpoints: 'lg xl xxl', // Only visible on large, extra-large, and extra-extra-large screens
-              child: Container(
-                padding: const EdgeInsets.all(8.0),
-                color: Colors.deepPurple.shade100,
-                child: const Text('Visible on LG, XL, XXL screens'),
-              ),
+              breakpoints: 'lg xl xxl',
+              child: _exampleBox('Visible on LG, XL, XXL screens', Colors.deepPurple.shade100, height: 60),
             ),
             NextResponsiveVisibility(
-              breakpoints: 'xs sm md', // Only visible on small and medium screens
-              child: Container(
-                padding: const EdgeInsets.all(8.0),
-                color: Colors.teal.shade100,
-                child: const Text('Visible on XS, SM, MD screens'),
-              ),
+              breakpoints: 'xs sm md',
+              child: _exampleBox('Visible on XS, SM, MD screens', Colors.teal.shade100, height: 60),
             ),
-            Container( // This container is always visible for comparison
-                margin: const EdgeInsets.only(top: 8),
+             const SizedBox(height: 8),
+
+            _buildSectionTitle(context, 'Example 2: Show only on one breakpoint', sub: true),
+             NextResponsiveVisibility(
+              breakpoints: 'md',
+              child: _exampleBox('VISIBLE ONLY ON MD', Colors.orange.shade200, height: 60),
+            ),
+            const SizedBox(height: 8),
+
+            _buildSectionTitle(context, 'Example 3: Swapping UI sections', sub: true),
+            _buildExplanation(context, 'Use multiple `NextResponsiveVisibility` widgets to show different content for different screen sizes.'),
+            NextResponsiveVisibility(
+              breakpoints: 'xs sm',
+              child: _exampleBox('Mobile View Content (XS, SM)', Colors.lightBlue.shade100, height: 80),
+            ),
+            NextResponsiveVisibility(
+              breakpoints: 'md lg',
+              child: _exampleBox('Tablet/Desktop View Content (MD, LG)', Colors.lightGreen.shade100, height: 80),
+            ),
+             NextResponsiveVisibility(
+              breakpoints: 'xl xxl',
+              child: _exampleBox('Large Desktop View Content (XL, XXL)', Colors.pink.shade200, height: 80),
+            ),
+
+            Container(
+                margin: const EdgeInsets.only(top: 16),
                 padding: const EdgeInsets.all(8.0),
                 color: Colors.grey.shade300,
-                child: const Text('This text is always visible (standard Container)'),
+                width: double.infinity,
+                child: const Text('This text is always visible (standard Container for comparison)', textAlign: TextAlign.center),
             ),
             const SizedBox(height: 20),
           ],

--- a/flutter_next/example/lib/pages/gridview_example.dart
+++ b/flutter_next/example/lib/pages/gridview_example.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_next/flutter_next.dart';
+import 'dart:math';
+
+class GridViewExamplePage extends StatelessWidget {
+  const GridViewExamplePage({super.key});
+
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12.0),
+      child: Text(title, style: Theme.of(context).textTheme.titleLarge),
+    );
+  }
+
+  Widget _buildExplanation(BuildContext context, String explanation) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0, bottom: 8.0),
+      child: Text(
+        explanation,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic, color: Colors.grey.shade700),
+      ),
+    );
+  }
+
+  Widget _exampleGridItem(int index, {Color? color}) {
+    final itemColor = color ?? Colors.primaries[Random().nextInt(Colors.primaries.length)].shade200;
+    return Container(
+      color: itemColor,
+      child: Center(
+        child: Text(
+          'Item $index',
+          style: const TextStyle(color: Colors.black54, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('NextGridView Examples'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _buildSectionTitle(context, 'Basic Responsive GridView'),
+            _buildExplanation(context,
+              'A responsive grid view where the number of items per row adapts to screen breakpoints. '
+              'The `widthPercentages` map defines the percentage of width each item takes at different `GridPrefix` breakpoints (xs, sm, md, lg, xl, xxl). '
+              'Items will wrap automatically. `mainAxisExtent` defines the height of each item.'),
+            NextGridView(
+              mainAxisExtent: 100, // Height of items
+              widthPercentages: const {
+                GridPrefix.xs: 100, // 1 item per row on extra-small
+                GridPrefix.sm: 50,  // 2 items per row on small
+                GridPrefix.md: 33.33, // 3 items per row on medium
+                GridPrefix.lg: 25,  // 4 items per row on large
+                GridPrefix.xl: 20,  // 5 items per row on extra-large
+              },
+              children: List.generate(10, (index) => _exampleGridItem(index + 1)),
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'GridView with Custom Spacing'),
+            _buildExplanation(context,
+              'Illustrates customizing the horizontal (`crossAxisSpacing`) and vertical (`mainAxisSpacing`) spacing between grid items.'),
+            NextGridView(
+              mainAxisExtent: 80,
+              crossAxisSpacing: 12.0,
+              mainAxisSpacing: 12.0,
+              widthPercentages: const {
+                GridPrefix.xs: 100,
+                GridPrefix.sm: 50,
+                GridPrefix.md: 25,
+              },
+              children: List.generate(8, (index) => _exampleGridItem(index + 1, color: Colors.teal.shade100)),
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'GridView with Fixed Item Count per Row (Non-Responsive)'),
+            _buildExplanation(context,
+              'If you only provide a width percentage for `GridPrefix.xs` (or any single breakpoint), '
+              'the grid will effectively have a fixed number of items per row across all screen sizes, '
+              'unless overridden by a more specific breakpoint.'),
+            _buildExplanation(context, 'Example: Always 2 items per row (using 50% for xs)'),
+            NextGridView(
+              mainAxisExtent: 70,
+              widthPercentages: const {
+                GridPrefix.xs: 50, // 2 items per row
+              },
+              children: List.generate(6, (index) => _exampleGridItem(index + 1, color: Colors.orange.shade100)),
+            ),
+            const SizedBox(height: 10),
+             _buildExplanation(context, 'Example: Always 3 items per row (using 33.33% for xs)'),
+            NextGridView(
+              mainAxisExtent: 70,
+               mainAxisSpacing: 5,
+               crossAxisSpacing: 5,
+              widthPercentages: const {
+                GridPrefix.xs: 33.33, // 3 items per row
+              },
+              children: List.generate(7, (index) => _exampleGridItem(index + 1, color: Colors.purple.shade100)),
+            ),
+            const SizedBox(height: 20),
+
+            _buildSectionTitle(context, 'GridView with Many Items (Scroll Performance)'),
+            _buildExplanation(context,
+              'Shows a grid view handling a larger number of items (50+) demonstrating its inherent scrollability if it overflows its parent constraints. '
+              'Note: If `NextGridView` is inside a `SingleChildScrollView` (like this page), it will expand to its full height. '
+              'For internal scrolling in `NextGridView` itself, it would need to be constrained by a parent with a fixed height (e.g., a SizedBox or Expanded).'),
+            SizedBox( // Constrain height to demonstrate internal scrollability if needed, though here it will just make the page longer.
+              // height: 300, // Example if you wanted NextGridView to scroll internally
+              child: NextGridView(
+                mainAxisExtent: 60,
+                mainAxisSpacing: 6,
+                crossAxisSpacing: 6,
+                widthPercentages: const {
+                  GridPrefix.xs: 50,
+                  GridPrefix.sm: 33.33,
+                  GridPrefix.md: 25,
+                  GridPrefix.lg: 20,
+                },
+                children: List.generate(50, (index) => _exampleGridItem(index + 1, color: Colors.cyan.shade50)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This commit introduces a significantly enhanced example application to serve as a comprehensive playground for various Flutter Next widgets.

Key changes:
- Created new dedicated example pages for:
  - NextAlerts (`alerts_example.dart`)
  - NextAccordion (`accordion_example.dart`)
  - NextAvatar & NextAvatarGroup (`avatar_example.dart` - new version)
  - NextBreadCrumb (`breadcrumb_example.dart`)
  - NextButton (`button_example.dart`)
  - NextGridView (`gridview_example.dart`)
- Each new example page features multiple use cases with detailed explanations and follows a standardized, clear structure.
- Significantly refactored and expanded `grid_layout_example.dart` to provide more granular and well-explained examples for NextContainer, NextRow, NextCol (Sizing, Offsetting, Ordering, Visibility), and NextResponsiveVisibility.
- Updated `main.dart` to provide clear navigation to all new and updated example pages from a central `ExampleHomePage`.
- Renamed the previous avatar example page to `avatar_showcase_legacy.dart` to preserve its content while introducing the new standardized avatar examples.

This provides you with a rich set of examples to understand and test the functionality of core Flutter Next UI components.